### PR TITLE
Document constructor settings, improve names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## keycloak-admin
 [![npm version](https://badge.fury.io/js/keycloak-admin.svg)](https://badge.fury.io/js/keycloak-admin) [![Travis (.org)](https://img.shields.io/travis/Canner/keycloak-admin.svg)](https://travis-ci.org/Canner/keycloak-admin)
 
-Nodejs keycloak admin client
+Node.js Keycloak admin client
 
 ## Features
 * Typescript supported
@@ -19,6 +19,12 @@ yarn add keycloak-admin
 ```js
 import KcAdminClient from 'keycloak-admin';
 
+// To configure the client, pass an object with any of these options:
+// {
+//   baseUrl?: string;
+//   realmName?: string;
+//   requestConfigs?: AxiosRequestConfig;
+// }
 const kcAdminClient = new KcAdminClient();
 
 // authorize with username/passowrd

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import KcAdminClient from 'keycloak-admin';
 // }
 const kcAdminClient = new KcAdminClient();
 
-// authorize with username/passowrd
+// authorize with username/password
 await kcAdminClient.auth({
   username: 'wwwy3y3',
   password: 'wwwy3y3',

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ await kcAdminClient.auth({
 });
 
 // list all users
-const users = await this.kcAdminClient.users.find();
+const users = await kcAdminClient.users.find();
 ```
 
 ## Supported APIs


### PR DESCRIPTION
Thanks for this project! It looks like it will be nicer to use than [`keycloak-admin-client`](https://github.com/keycloak/keycloak-admin-client).

I noticed that the constructor settings are not documented in the quick readme example. This fixes that, some names and typos and removes the extra `this`.