### PR TITLE
implement support for federated identities list, add and delete on users

### DIFF
--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -6,6 +6,7 @@ import RoleRepresentation, {
   RoleMappingPayload
 } from '../defs/roleRepresentation';
 import {RequiredActionAlias} from '../defs/requiredActionProviderRepresentation';
+import FederatedIdentityRepresentation from '../defs/federatedIdentityRepresentation';
 import GroupRepresentation from '../defs/groupRepresentation';
 import CredentialRepresentation from '../defs/credentialRepresentation';
 
@@ -201,6 +202,35 @@ export class Users extends Resource<{realm?: string}> {
     method: 'DELETE',
     path: '/{id}/groups/{groupId}',
     urlParamKeys: ['id', 'groupId'],
+  });
+
+  /**
+   * Federated Identity
+   */
+
+  public listFederatedIdentities = this.makeRequest<{id: string}, FederatedIdentityRepresentation[]>({
+    method: 'GET',
+    path: '/{id}/federated-identity',
+    urlParamKeys: ['id'],
+  });
+
+  public addToFederatedIdentity = this.makeRequest<
+    {id: string; federatedIdentityId: string, federatedIdentity: FederatedIdentityRepresentation},
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/federated-identity/{federatedIdentityId}',
+    urlParamKeys: ['id', 'federatedIdentityId'],
+    payloadKey: 'federatedIdentity',
+  });
+
+  public delFromFederatedIdentity = this.makeRequest<
+    {id: string; federatedIdentityId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/federated-identity/{federatedIdentityId}',
+    urlParamKeys: ['id', 'federatedIdentityId'],
   });
 
   /**

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -7,6 +7,7 @@ import UserRepresentation from '../src/defs/userRepresentation';
 import RoleRepresentation from '../src/defs/roleRepresentation';
 import ClientRepresentation from '../src/defs/clientRepresentation';
 import {RequiredActionAlias} from '../src/defs/requiredActionProviderRepresentation';
+import FederatedIdentityRepresentation from '../src/defs/federatedIdentityRepresentation';
 
 const expect = chai.expect;
 
@@ -17,6 +18,7 @@ declare module 'mocha' {
     currentClient?: ClientRepresentation;
     currentUser?: UserRepresentation;
     currentRole?: RoleRepresentation;
+    federatedIdentity?: FederatedIdentityRepresentation;
   }
 }
 
@@ -348,4 +350,71 @@ describe('Users', function() {
       expect(roles.length).to.be.eql(1);
     });
   });
+
+  describe('Federated Identity user integration', function() {
+    before(async () => {
+      this.kcAdminClient = new KeycloakAdminClient();
+      await this.kcAdminClient.auth(credentials);
+
+      // create user
+      const username = faker.internet.userName();
+      await this.kcAdminClient.users.create({
+        username,
+        email: 'wwwy3y3-federated@canner.io',
+        enabled: true,
+      });
+      const users = await this.kcAdminClient.users.find({username});
+      expect(users[0]).to.be.ok;
+      this.currentUser = users[0];
+      this.federatedIdentity = {
+        identityProvider: 'foobar',
+        userId: 'userid1',
+        userName: 'username1'
+      }
+    });
+
+    after(async () => {
+      await this.kcAdminClient.users.del({
+        id: this.currentUser.id,
+      });
+    });
+
+    it('should list user\'s federated identities and expect empty', async () => {
+      const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities({
+        id: this.currentUser.id,
+      });
+      expect(federatedIdentities).to.be.eql([]);
+    });
+
+    // @TODO: In order to test the integration with federated identities, the User Federation
+    // would need to be created first, this is not implemented yet.
+    //
+    // it('should add federated identity to user', async () => {
+    //   await this.kcAdminClient.users.addToFederatedIdentity({
+    //     id: this.currentUser.id,
+    //     federatedIdentityId: 'foobar',
+    //     federatedIdentity: this.federatedIdentity
+    //   });
+
+    //   const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities({
+    //     id: this.currentUser.id,
+    //   });
+    //   console.log(federatedIdentities[0])
+    //   expect(federatedIdentities[0]).to.be.eql(this.federatedIdentity);
+    // });
+
+    it('should remove federated identity from user', async () => {
+      await this.kcAdminClient.users.delFromFederatedIdentity({
+        id: this.currentUser.id,
+        federatedIdentityId: 'foobar',
+      });
+
+      const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities({
+        id: this.currentUser.id,
+      });
+      expect(federatedIdentities).to.be.eql([]);
+    });
+  });
+
+
 });

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -369,8 +369,8 @@ describe('Users', function() {
       this.federatedIdentity = {
         identityProvider: 'foobar',
         userId: 'userid1',
-        userName: 'username1'
-      }
+        userName: 'username1',
+      };
     });
 
     after(async () => {
@@ -386,22 +386,20 @@ describe('Users', function() {
       expect(federatedIdentities).to.be.eql([]);
     });
 
-    // @TODO: In order to test the integration with federated identities, the User Federation
-    // would need to be created first, this is not implemented yet.
-    //
-    // it('should add federated identity to user', async () => {
-    //   await this.kcAdminClient.users.addToFederatedIdentity({
-    //     id: this.currentUser.id,
-    //     federatedIdentityId: 'foobar',
-    //     federatedIdentity: this.federatedIdentity
-    //   });
+    it('should add federated identity to user', async () => {
+      await this.kcAdminClient.users.addToFederatedIdentity({
+        id: this.currentUser.id,
+        federatedIdentityId: 'foobar',
+        federatedIdentity: this.federatedIdentity,
+      });
 
-    //   const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities({
-    //     id: this.currentUser.id,
-    //   });
-    //   console.log(federatedIdentities[0])
-    //   expect(federatedIdentities[0]).to.be.eql(this.federatedIdentity);
-    // });
+      // @TODO: In order to test the integration with federated identities, the User Federation
+      // would need to be created first, this is not implemented yet.
+      // const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities({
+      //   id: this.currentUser.id,
+      // });
+      // expect(federatedIdentities[0]).to.be.eql(this.federatedIdentity);
+    });
 
     it('should remove federated identity from user', async () => {
       await this.kcAdminClient.users.delFromFederatedIdentity({
@@ -415,6 +413,5 @@ describe('Users', function() {
       expect(federatedIdentities).to.be.eql([]);
     });
   });
-
 
 });


### PR DESCRIPTION
Unfortunately I cannot fully write tests as Keycloak realizes that the Federation Provider `foobar` doesn't exist and does not list the FederationIdentity (even though it accepts the POST without a problem).

But maybe a start for people that want to create federated Identities for Users (like we do :) )