### PR TITLE
Document OpenID token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ await kcAdminClient.auth({
   username: 'wwwy3y3',
   password: 'wwwy3y3',
   grantType: 'password',
-  clientId: 'admin-cli'
+  clientId: 'admin-cli',
 });
 
 // List all users
@@ -56,7 +56,7 @@ const groups = await kcAdminClient.groups.find();
 await this.kcAdminClient.users.create({
   realm: 'a-third-realm',
   username: 'username',
-  email: 'user@example.com'
+  email: 'user@example.com',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ await this.kcAdminClient.users.create({
 });
 ```
 
+To refresh the acces token provided by Keycloak, an OpenID client like [panva/node-openid-client](https://github.com/panva/node-openid-client) can be used like this:
+
+```js
+import {Issuer} from 'openid-client';
+
+const keycloakIssuer = await Issuer.discover(
+  'http://localhost:8080/auth/realms/master'
+);
+
+const client = new keycloakIssuer.Client({
+  client_id: 'admin-cli', // Same as `clientId` passed to client.auth()
+  client_secret: 'wwwy3y3', // Same as `password` passed to client.auth()
+});
+
+setInterval(async () => {
+  const refreshToken = client.refreshToken;
+  const tokenSet = await client.refresh(refreshToken);
+  kcAdminClient.setAccessToken(tokenSet.access_token);
+}, 58 * 1000); // 58 seconds
+```
+
 ## Supported APIs
 
 ### [Realm admin](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_realms_admin_resource)

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   bracketSpacing: false,
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'all',
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,7 @@ export class KeycloakAdminClient {
   public baseUrl: string;
   public realmName: string;
   public accessToken: string;
+  public refreshToken: string;
   private requestConfig?: AxiosRequestConfig;
 
   constructor(connectionConfig?: ConnectionConfig) {
@@ -49,13 +50,14 @@ export class KeycloakAdminClient {
   }
 
   public async auth(credentials: Credentials) {
-    const {accessToken} = await getToken({
+    const {accessToken, refreshToken} = await getToken({
       baseUrl: this.baseUrl,
       realmName: this.realmName,
       credentials,
       requestConfig: this.requestConfig,
     });
     this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
   }
 
   public setAccessToken(token: string) {


### PR DESCRIPTION
Expose `refreshToken` on clients and document refreshing the token with an OpenID library like [panva/node-openid-client](https://github.com/panva/node-openid-client)

Not sure if I got the values for the following things correct (they seemed to work in my tests):

- discover string
- `client_id`
- `client_secret`